### PR TITLE
fix(patch): [sc-4897] move rebalance callback storage to rd kafka client

### DIFF
--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -164,8 +164,6 @@ public final class KafkaConsumer: Sendable, Service {
     /// State of the `KafkaConsumer`.
     private let stateMachine: NIOLockedValueBox<StateMachine>
     
-    private let rebalanceCbStorage: RDKafkaClient.RebalanceCallbackStorage?
-
     /// An asynchronous sequence containing messages from the Kafka cluster.
     public let messages: KafkaConsumerMessages
 
@@ -185,13 +183,11 @@ public final class KafkaConsumer: Sendable, Service {
         stateMachine: NIOLockedValueBox<StateMachine>,
         configuration: KafkaConsumerConfiguration,
         logger: Logger,
-        eventSource: ProducerEvents.Source? = nil,
-        rebalanceCbStorage: RDKafkaClient.RebalanceCallbackStorage? = nil
+        eventSource: ProducerEvents.Source? = nil
     ) throws {
         self.configuration = configuration
         self.stateMachine = stateMachine
         self.logger = logger
-        self.rebalanceCbStorage = rebalanceCbStorage // save to avoid destruction
         
         
         let sourceAndSequence = NIOThrowingAsyncSequenceProducer.makeSequence(
@@ -347,8 +343,7 @@ public final class KafkaConsumer: Sendable, Service {
             stateMachine: stateMachine,
             configuration: configuration,
             logger: logger,
-            eventSource: sourceAndSequence.source,
-            rebalanceCbStorage: rebalanceCallBackStorage
+            eventSource: sourceAndSequence.source
         )
         wrapper.consumer = consumer
 

--- a/Sources/Kafka/RDKafka/RDKafkaClient.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaClient.swift
@@ -35,6 +35,8 @@ final class RDKafkaClient: Sendable {
 
     /// `librdkafka`'s `rd_kafka_queue_t` that events are received on.
     private let queue: OpaquePointer
+    
+    private let rebalanceCallBackStorage: RebalanceCallbackStorage?
 
     /// Queue for blocking calls outside of cooperative thread pool
     private var gcdQueue: DispatchQueue {
@@ -46,11 +48,13 @@ final class RDKafkaClient: Sendable {
     private init(
         type: ClientType,
         kafkaHandle: OpaquePointer,
-        logger: Logger
+        logger: Logger,
+        rebalanceCallBackStorage: RebalanceCallbackStorage? = nil
     ) {
         self.kafkaHandle = kafkaHandle
         self.logger = logger
         self.queue = rd_kafka_queue_get_main(self.kafkaHandle)
+        self.rebalanceCallBackStorage = rebalanceCallBackStorage
 
         rd_kafka_set_log_queue(self.kafkaHandle, self.queue)
     }
@@ -133,7 +137,7 @@ final class RDKafkaClient: Sendable {
             throw KafkaError.client(reason: errorString)
         }
 
-        return RDKafkaClient(type: type, kafkaHandle: handle, logger: logger)
+        return RDKafkaClient(type: type, kafkaHandle: handle, logger: logger, rebalanceCallBackStorage: rebalanceCallBackStorage)
     }
 
     /// Produce a message to the Kafka cluster.


### PR DESCRIPTION
Move rebalance callback to destroy it after rd kafka client.