### PR TITLE
chore(minor): [sc-2373] allow to get metadata from broker

### DIFF
--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -454,6 +454,10 @@ public final class KafkaConsumer: Sendable, Service {
             throw KafkaError.client(reason: err)
         }
     }
+    
+    public func metadata() async throws -> KafkaMetadata {
+        try await client().metadata()
+    }
 
     /// Start the ``KafkaConsumer``.
     ///
@@ -1058,7 +1062,7 @@ extension KafkaConsumer {
             case .uninitialized:
                 fatalError("\(#function) invoked while still in state \(self.state)")
             case .initializing:
-                fatalError("Subscribe to consumer group / assign to topic partition pair before reading messages")
+                self.state = .finished
             case .running(let client, _, let eventSource):
                 self.state = .running(client: client, messagePollLoopState: .finished, eventSource: eventSource)
             case .finishing, .finished:

--- a/Sources/Kafka/KafkaMetadata.swift
+++ b/Sources/Kafka/KafkaMetadata.swift
@@ -1,0 +1,70 @@
+import Crdkafka
+
+public final class KafkaMetadata {
+    private let metadata: UnsafePointer<rd_kafka_metadata>
+    
+    init(metadata: UnsafePointer<rd_kafka_metadata>) {
+        self.metadata = metadata
+    }
+    
+    deinit {
+        rd_kafka_metadata_destroy(metadata)
+    }
+    
+    public var topics: [KafkaMetadataTopic] {
+        let metadata = self.metadata.pointee
+        let topicCount = Int(metadata.topic_cnt)
+        var topics = [KafkaMetadataTopic]()
+        topics.reserveCapacity(topicCount)
+        
+        for i in 0..<topicCount {
+            topics.append(.init(metadata: self, topic: metadata.topics[i]))
+        }
+        return topics
+    }
+}
+
+public struct KafkaMetadataTopic {
+    private let metadata: KafkaMetadata // retain metadata
+    private let topic: rd_kafka_metadata_topic
+    
+    init(metadata: KafkaMetadata, topic: rd_kafka_metadata_topic) {
+        self.metadata = metadata
+        self.topic = topic
+    }
+    
+    public var name: String {
+        String(cString: topic.topic)
+    }
+    
+    public var partitions: [KafkaMetadataPartition] {
+        let partitionCount = Int(topic.partition_cnt)
+        
+        var partitions = [KafkaMetadataPartition]()
+        partitions.reserveCapacity(partitionCount)
+        
+        for i in 0..<partitionCount {
+            partitions.append(.init(metadata: metadata, partition: topic.partitions[i]))
+        }
+        
+        return partitions
+    }
+}
+
+public struct KafkaMetadataPartition {
+    private let metadata: KafkaMetadata // retain metadata
+    private let partition: rd_kafka_metadata_partition
+    
+    init(metadata: KafkaMetadata, partition: rd_kafka_metadata_partition) {
+        self.metadata = metadata
+        self.partition = partition
+    }
+    
+    var id: Int {
+        Int(partition.id)
+    }
+
+    var replicasCount: Int {
+        Int(partition.replica_cnt)
+    }
+}

--- a/Sources/Kafka/KafkaMetadata.swift
+++ b/Sources/Kafka/KafkaMetadata.swift
@@ -12,12 +12,12 @@ public final class KafkaMetadata {
     }
     
     public private(set) lazy var topics = {
-        (0..<Int(self.metadata.pointee.topic_cnt)).map { KafkaMetadataTopic(metadata: self, topic: self.metadata.pointee.topics[$0]) }
+        (0..<Int(self.metadata.pointee.topic_cnt)).map { KafkaTopicMetadata(metadata: self, topic: self.metadata.pointee.topics[$0]) }
     }()
 }
 
 // must be a class to allow mutating lazy vars, otherwise require struct copies
-public final class KafkaMetadataTopic {
+public final class KafkaTopicMetadata {
     private let metadata: KafkaMetadata // retain metadata
     private let topic: rd_kafka_metadata_topic
     
@@ -31,11 +31,11 @@ public final class KafkaMetadataTopic {
     }()
     
     public private(set) lazy var partitions = {
-        (0..<Int(self.topic.partition_cnt)).map { KafkaMetadataPartition(metadata: self.metadata, partition: topic.partitions[$0]) }
+        (0..<Int(self.topic.partition_cnt)).map { KafkaPartitionMetadata(metadata: self.metadata, partition: topic.partitions[$0]) }
     }()
 }
 
-public struct KafkaMetadataPartition {
+public struct KafkaPartitionMetadata {
     private let metadata: KafkaMetadata // retain metadata
     private let partition: rd_kafka_metadata_partition
     

--- a/Sources/Kafka/KafkaMetadata.swift
+++ b/Sources/Kafka/KafkaMetadata.swift
@@ -12,15 +12,7 @@ public final class KafkaMetadata {
     }
     
     public private(set) lazy var topics = {
-        let metadata = self.metadata.pointee
-        let topicCount = Int(metadata.topic_cnt)
-        var topics = [KafkaMetadataTopic]()
-        topics.reserveCapacity(topicCount)
-        
-        for i in 0..<topicCount {
-            topics.append(.init(metadata: self, topic: metadata.topics[i]))
-        }
-        return topics
+        (0..<Int(self.metadata.pointee.topic_cnt)).map { KafkaMetadataTopic(metadata: self, topic: self.metadata.pointee.topics[$0]) }
     }()
 }
 
@@ -39,16 +31,7 @@ public final class KafkaMetadataTopic {
     }()
     
     public private(set) lazy var partitions = {
-        let partitionCount = Int(self.topic.partition_cnt)
-        
-        var partitions = [KafkaMetadataPartition]()
-        partitions.reserveCapacity(partitionCount)
-        
-        for i in 0..<partitionCount {
-            partitions.append(.init(metadata: self.metadata, partition: topic.partitions[i]))
-        }
-        
-        return partitions
+        (0..<Int(self.topic.partition_cnt)).map { KafkaMetadataPartition(metadata: self.metadata, partition: topic.partitions[$0]) }
     }()
 }
 


### PR DESCRIPTION
## Description

Sometimes it is required to get partitions count from kafka, e.g. to collect all partitions EOF
So adding ad-hoc api for metadata.

## How Has This Been Tested?

Unit test for getting metadata

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
