### PR TITLE
chore(patch): [sc-5640] remove async stream: wrap `rd_kafka_consumer_poll` as AsyncSequence

### DIFF
--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -34,23 +34,6 @@ extension KafkaConsumerEventsDelegate: NIOAsyncSequenceProducerDelegate {
     }
 }
 
-// MARK: - KafkaConsumerMessagesDelegate
-
-/// `NIOAsyncSequenceProducerDelegate` for ``KafkaConsumerMessages``.
-internal struct KafkaConsumerMessagesDelegate: Sendable {
-    let stateMachine: NIOLockedValueBox<KafkaConsumer.StateMachine>
-}
-
-extension KafkaConsumerMessagesDelegate: NIOAsyncSequenceProducerDelegate {
-    func produceMore() {
-        self.stateMachine.withLockedValue { $0.produceMore() }
-    }
-
-    func didTerminate() {
-        self.stateMachine.withLockedValue { $0.finishMessageConsumption() }
-    }
-}
-
 // MARK: - KafkaConsumerEvents
 
 /// `AsyncSequence` implementation for handling ``KafkaConsumerEvent``s emitted by Kafka.
@@ -78,68 +61,83 @@ public struct KafkaConsumerEvents: Sendable, AsyncSequence {
 
 /// `AsyncSequence` implementation for handling messages received from the Kafka cluster (``KafkaConsumerMessage``).
 public struct KafkaConsumerMessages: Sendable, AsyncSequence {
-    let stateMachine: NIOLockedValueBox<KafkaConsumer.StateMachine>
+    typealias LockedMachine = NIOLockedValueBox<KafkaConsumer.StateMachine>
+    
+    let stateMachine: LockedMachine
+    let pollInterval: Duration
     let enablePartitionEof: Bool
 
     public typealias Element = KafkaConsumerMessage
-    typealias BackPressureStrategy = NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark
-    typealias WrappedSequence = NIOThrowingAsyncSequenceProducer<
-        Result<KafkaConsumerMessage, Error>,
-        Error,
-        BackPressureStrategy,
-        KafkaConsumerMessagesDelegate
-    >
-    let wrappedSequence: WrappedSequence
 
     /// `AsynceIteratorProtocol` implementation for handling messages received from the Kafka cluster (``KafkaConsumerMessage``).
     public struct AsyncIterator: AsyncIteratorProtocol {
-        let stateMachine: NIOLockedValueBox<KafkaConsumer.StateMachine>
-        var wrappedIterator: WrappedSequence.AsyncIterator?
+        private let stateMachine: MachineHolder
+        let pollInterval: Duration
         let enablePartitionEof: Bool
+        
+        weak var cachedClient: RDKafkaClient?
+        var messagesCount: Int = 0
+        
+        private final class MachineHolder: Sendable { // only for deinit
+            let stateMachine: LockedMachine
+            init(stateMachine: LockedMachine) {
+                self.stateMachine = stateMachine
+            }
 
-        public mutating func next() async throws -> Element? {
-            repeat {
-                guard let result = try await self.wrappedIterator?.next() else {
-                    self.deallocateIterator()
-                    return nil
-                }
-                
-                switch result {
-                case .success(let message):
-                    let action = self.stateMachine.withLockedValue { $0.storeOffset() }
-                    switch action {
-                    case .storeOffset(let client):
-                        do {
-                            try client.storeMessageOffset(message)
-                        } catch {
-                            self.deallocateIterator()
-                            throw error
-                        }
-                        if !enablePartitionEof && message.eof {
-                            continue
-                        }
-                        return message
-                    case .terminateConsumerSequence:
-                        self.deallocateIterator()
-                        return nil
-                    }
-                case .failure(let error):
-                    self.deallocateIterator()
-                    throw error
-                }
-            } while true
+            deinit {
+                self.stateMachine.withLockedValue { $0.finishMessageConsumption() }
+            }
+        }
+        
+        init(stateMachine: LockedMachine, pollInterval: Duration, enablePartitionEof: Bool) {
+            self.stateMachine = .init(stateMachine: stateMachine)
+            self.pollInterval = pollInterval
+            self.enablePartitionEof = enablePartitionEof
         }
 
-        private mutating func deallocateIterator() {
-            self.wrappedIterator = nil
+        public mutating func next() async throws -> Element? {
+            defer {
+                self.messagesCount += 1
+                if self.messagesCount >= 100 {
+                    self.cachedClient = nil
+                    self.messagesCount = 0
+                }
+            }
+            while !Task.isCancelled {
+                if let client = self.cachedClient, // fast path
+                   let message = try client.consumerPoll() {
+                    return message
+                }
+                let action = self.stateMachine.stateMachine.withLockedValue { $0.nextConsumerPollLoopAction() }
+                switch action {
+                case .poll(let client):
+                    let message = try client.consumerPoll()
+                    guard let message else {
+                        self.cachedClient = nil
+                        self.messagesCount = 0
+                        try await Task.sleep(for: self.pollInterval)
+                        continue
+                    }
+                    if message.eof && !self.enablePartitionEof{
+                        continue
+                    }
+                    self.cachedClient = client
+                    return message
+                case .suspendPollLoop:
+                    try await Task.sleep(for: self.pollInterval)
+                case .terminatePollLoop:
+                    return nil
+                }
+            }
+            return nil
         }
     }
 
     public func makeAsyncIterator() -> AsyncIterator {
         return AsyncIterator(
             stateMachine: self.stateMachine,
-            wrappedIterator: self.wrappedSequence.makeAsyncIterator(),
-            enablePartitionEof: enablePartitionEof
+            pollInterval: self.pollInterval,
+            enablePartitionEof: self.enablePartitionEof
         )
     }
 }
@@ -148,12 +146,6 @@ public struct KafkaConsumerMessages: Sendable, AsyncSequence {
 
 /// A ``KafkaConsumer `` can be used to consume messages from a Kafka cluster.
 public final class KafkaConsumer: Sendable, Service {
-    typealias Producer = NIOThrowingAsyncSequenceProducer<
-        Result<KafkaConsumerMessage, Error>,
-        Error,
-        NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark,
-        KafkaConsumerMessagesDelegate
-    >
     typealias ProducerEvents = NIOAsyncSequenceProducer<
         KafkaConsumerEvent,
         NIOAsyncSequenceProducerBackPressureStrategies.NoBackPressure,
@@ -191,32 +183,16 @@ public final class KafkaConsumer: Sendable, Service {
         self.configuration = configuration
         self.stateMachine = stateMachine
         self.logger = logger
-        
-        
-        let sourceAndSequence = NIOThrowingAsyncSequenceProducer.makeSequence(
-            elementType: Result<KafkaConsumerMessage, Error>.self,
-            backPressureStrategy: {
-                switch configuration.backPressureStrategy._internal {
-                case .watermark(let lowWatermark, let highWatermark):
-                    return NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark(
-                        lowWatermark: lowWatermark,
-                        highWatermark: highWatermark
-                    )
-                }
-            }(),
-            delegate: KafkaConsumerMessagesDelegate(stateMachine: self.stateMachine)
-        )
 
         self.messages = KafkaConsumerMessages(
             stateMachine: self.stateMachine,
-            enablePartitionEof: configuration.enablePartitionEof,
-            wrappedSequence: sourceAndSequence.sequence
+            pollInterval: configuration.pollInterval,
+            enablePartitionEof: configuration.enablePartitionEof
         )
 
         self.stateMachine.withLockedValue {
             $0.initialize(
                 client: client,
-                source: sourceAndSequence.source,
                 eventSource: eventSource
             )
         }
@@ -339,6 +315,7 @@ public final class KafkaConsumer: Sendable, Service {
         let sourceAndSequence = NIOAsyncSequenceProducer.makeSequence(
             elementType: KafkaConsumerEvent.self,
             backPressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.NoBackPressure(),
+            finishOnDeinit: true,
             delegate: KafkaConsumerEventsDelegate(stateMachine: stateMachine)
         )
         
@@ -477,7 +454,8 @@ public final class KafkaConsumer: Sendable, Service {
         case .group(groupID: _, topics: let topics):
             try self.subscribe(topics: topics)
         }
-
+        try await self.eventRunLoop()
+        /*
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
                 try await self.eventRunLoop()
@@ -491,6 +469,7 @@ public final class KafkaConsumer: Sendable, Service {
             try await group.next()
             try await group.next()
         }
+         */
     }
 
     /// Run loop polling Kafka for new events.
@@ -527,7 +506,7 @@ public final class KafkaConsumer: Sendable, Service {
             }
         }
     }
-
+/*
     /// Run loop polling Kafka for new consumer messages.
     private func messageRunLoop() async throws {
         let maxAllowedMessages: Int
@@ -578,7 +557,7 @@ public final class KafkaConsumer: Sendable, Service {
             }
         }
     }
-
+*/
     /// Read `maxMessages` consumer messages from Kafka.
     ///
     /// - Parameters:
@@ -706,25 +685,6 @@ public final class KafkaConsumer: Sendable, Service {
 extension KafkaConsumer {
     /// State machine representing the state of the ``KafkaConsumer``.
     struct StateMachine: Sendable {
-        /// State of the event loop fetching new consumer messages.
-        enum MessagePollLoopState {
-            /// The sequence can take more messages.
-            ///
-            /// - Parameter source: The source for yielding new messages.
-            case running(source: Producer.Source)
-            /// Sequence suspended due to back pressure.
-            ///
-            /// - Parameter source: The source for yielding new messages.
-            case suspended(source: Producer.Source)
-            /// We have read to the end of a partition and are now waiting for new messages
-            /// to be produced.
-            ///
-            /// - Parameter source: The source for yielding new messages.
-            case waitingForMessages(source: Producer.Source)
-            /// The sequence has finished, and no more messages will be produced.
-            case finished
-        }
-
         /// The state of the ``StateMachine``.
         enum State: Sendable {
             /// The state machine has been initialized with init() but is not yet Initialized
@@ -738,15 +698,13 @@ extension KafkaConsumer {
             /// - Parameter eventSource: ``NIOAsyncSequenceProducer/Source`` used for yielding new events.
             case initializing(
                 client: RDKafkaClient,
-                source: Producer.Source,
                 eventSource: ProducerEvents.Source?
             )
             /// The ``KafkaConsumer`` is consuming messages.
             ///
             /// - Parameter client: Client used for handling the connection to the Kafka cluster.
-            /// - Parameter state: State of the event loop fetching new consumer messages.
             /// - Parameter eventSource: ``NIOAsyncSequenceProducer/Source`` used for yielding new events.
-            case running(client: RDKafkaClient, messagePollLoopState: MessagePollLoopState, eventSource: ProducerEvents.Source?)
+            case running(client: RDKafkaClient, eventSource: ProducerEvents.Source?)
             /// The ``KafkaConsumer/triggerGracefulShutdown()`` has been invoked.
             /// We are now in the process of commiting our last state to the broker.
             ///
@@ -764,7 +722,6 @@ extension KafkaConsumer {
         /// not yet available when the normal initialization occurs.
         mutating func initialize(
             client: RDKafkaClient,
-            source: Producer.Source,
             eventSource: ProducerEvents.Source?
         ) {
             guard case .uninitialized = self.state else {
@@ -772,7 +729,6 @@ extension KafkaConsumer {
             }
             self.state = .initializing(
                 client: client,
-                source: source,
                 eventSource: eventSource
             )
         }
@@ -800,7 +756,7 @@ extension KafkaConsumer {
                 fatalError("\(#function) invoked while still in state \(self.state)")
             case .initializing:
                 fatalError("Subscribe to consumer group / assign to topic partition pair before reading messages")
-            case .running(let client, _, let eventSource):
+            case .running(let client, let eventSource):
                 return .pollForEvents(client: client, eventSource: eventSource)
             case .finishing(let client, let eventSource):
                 if client.isConsumerClosed {
@@ -816,23 +772,11 @@ extension KafkaConsumer {
 
         /// Action to be taken when wanting to poll for a new message.
         enum ConsumerPollLoopAction {
-            /// Poll for a new ``KafkaConsumerMessage``.
-            ///
-            /// - Parameter client: Client used for handling the connection to the Kafka cluster.
-            /// - Parameter source: ``NIOAsyncSequenceProducer/Source`` used for yielding new elements.
-            case pollForAndYieldMessages(
-                client: RDKafkaClient,
-                source: Producer.Source
-            )
             /// Poll for a new ``KafkaConsumerMessage`` or sleep for ``KafkaConsumerConfiguration/pollInterval``
             /// if there are no new messages to read from the partition.
             ///
             /// - Parameter client: Client used for handling the connection to the Kafka cluster.
-            /// - Parameter source: ``NIOAsyncSequenceProducer/Source`` used for yielding new elements.
-            case pollForMessagesIfAvailable(
-                client: RDKafkaClient,
-                source: Producer.Source
-            )
+            case poll(client: RDKafkaClient)
             /// Sleep for ``KafkaConsumerConfiguration/pollInterval``.
             case suspendPollLoop
             /// Terminate the poll loop.
@@ -848,18 +792,9 @@ extension KafkaConsumer {
             case .uninitialized:
                 fatalError("\(#function) invoked while still in state \(self.state)")
             case .initializing:
-                fatalError("Subscribe to consumer group / assign to topic partition pair before reading messages")
-            case .running(let client, let consumerState, _):
-                switch consumerState {
-                case .running(let source):
-                    return .pollForAndYieldMessages(client: client, source: source)
-                case .suspended(source: _):
-                    return .suspendPollLoop
-                case .waitingForMessages(let source):
-                    return .pollForMessagesIfAvailable(client: client, source: source)
-                case .finished:
-                    return .terminatePollLoop
-                }
+                return .suspendPollLoop
+            case .running(let client, _):
+                return .poll(client: client)
             case .finishing, .finished:
                 return .terminatePollLoop
             }
@@ -879,8 +814,8 @@ extension KafkaConsumer {
             switch self.state {
             case .uninitialized:
                 fatalError("\(#function) invoked while still in state \(self.state)")
-            case .initializing(let client, let source, let eventSource):
-                self.state = .running(client: client, messagePollLoopState: .running(source: source), eventSource: eventSource)
+            case .initializing(let client, let eventSource):
+                self.state = .running(client: client, eventSource: eventSource)
                 return .setUpConnection(client: client)
             case .running:
                 fatalError("\(#function) should not be invoked more than once")
@@ -906,7 +841,7 @@ extension KafkaConsumer {
                 fatalError("\(#function) invoked while still in state \(self.state)")
             case .initializing:
                 fatalError("Subscribe to consumer group / assign to topic partition pair before reading messages")
-            case .running(let client, _, _):
+            case .running(let client, _):
                 return .storeOffset(client: client)
             case .finishing, .finished:
                 return .terminateConsumerSequence
@@ -933,7 +868,7 @@ extension KafkaConsumer {
                 fatalError("\(#function) invoked while still in state \(self.state)")
             case .initializing:
                 fatalError("Subscribe to consumer group / assign to topic partition pair before reading messages")
-            case .running(let client, _, _):
+            case .running(let client, _):
                 return .commit(client: client)
             case .finishing, .finished:
                 return .throwClosedError
@@ -958,7 +893,7 @@ extension KafkaConsumer {
                 fatalError("\(#function) invoked while still in state \(self.state)")
             case .initializing:
                 fatalError("Subscribe to consumer group / assign to topic partition pair before reading messages")
-            case .running(let client, _, let eventSource):
+            case .running(let client, let eventSource):
                 self.state = .finishing(client: client, eventSource: eventSource)
                 return .triggerGracefulShutdown(client: client)
             case .finishing, .finished:
@@ -984,76 +919,12 @@ extension KafkaConsumer {
                 fatalError("\(#function) should not be invoked in state \(self.state)")
             case .initializing:
                 fatalError("\(#function) should not be invoked in state \(self.state)")
-            case .running(let client, _, _):
+            case .running(let client, _):
                 return .allowed(client: client)
             case .finishing(let client, _):
                 return .allowed(client: client)
             case .finished:
                 return .denied(error: "Consumer finished")
-            }
-        }
-        // MARK: - Consumer Messages Poll Loop Actions
-
-        /// The partition that was previously finished reading has got new messages produced to it.
-        mutating func newMessagesProduced() {
-            guard case .running(let client, let consumerState, let eventSource) = self.state else {
-                fatalError("\(#function) invoked while still in state \(self.state)")
-            }
-
-            switch consumerState {
-            case .running, .suspended, .finished:
-                fatalError("\(#function) should not be invoked in state \(self.state)")
-            case .waitingForMessages(let source):
-                self.state = .running(client: client, messagePollLoopState: .running(source: source), eventSource: eventSource)
-            }
-        }
-
-        /// The consumer has read to the end of a partition and shall now go into a sleep loop until new messages are produced.
-        mutating func waitForNewMessages() {
-            guard case .running(let client, let consumerState, let eventSource) = self.state else {
-                fatalError("\(#function) invoked while still in state \(self.state)")
-            }
-
-            switch consumerState {
-            case .running(let source):
-                self.state = .running(client: client, messagePollLoopState: .waitingForMessages(source: source), eventSource: eventSource)
-            case .suspended, .waitingForMessages, .finished:
-                fatalError("\(#function) should not be invoked in state \(self.state)")
-            }
-        }
-
-        /// ``KafkaConsumerMessages``'s back pressure mechanism asked us to produce more messages.
-        mutating func produceMore() {
-            switch self.state {
-            case .uninitialized:
-                fatalError("\(#function) invoked while still in state \(self.state)")
-            case .initializing:
-                break // This case can be triggered by the KafkaConsumerMessagesDeletgate
-            case .running(let client, let consumerState, let eventSource):
-                switch consumerState {
-                case .running, .waitingForMessages, .finished:
-                    break
-                case .suspended(let source):
-                    self.state = .running(client: client, messagePollLoopState: .running(source: source), eventSource: eventSource)
-                }
-            case .finishing, .finished:
-                break
-            }
-        }
-
-        /// ``KafkaConsumerMessages``'s back pressure mechanism asked us to temporarily stop producing messages.
-        mutating func stopProducing() {
-            guard case .running(let client, let consumerState, let eventSource) = self.state else {
-                fatalError("\(#function) invoked while still in state \(self.state)")
-            }
-
-            switch consumerState {
-            case .suspended, .finished:
-                break
-            case .running(let source):
-                self.state = .running(client: client, messagePollLoopState: .suspended(source: source), eventSource: eventSource)
-            case .waitingForMessages(let source):
-                self.state = .running(client: client, messagePollLoopState: .suspended(source: source), eventSource: eventSource)
             }
         }
 
@@ -1064,8 +935,8 @@ extension KafkaConsumer {
                 fatalError("\(#function) invoked while still in state \(self.state)")
             case .initializing:
                 self.state = .finished
-            case .running(let client, _, let eventSource):
-                self.state = .running(client: client, messagePollLoopState: .finished, eventSource: eventSource)
+            case .running(let client, let eventSource):
+                self.state = .finished
             case .finishing, .finished:
                 break
             }
@@ -1075,9 +946,9 @@ extension KafkaConsumer {
             switch self.state {
             case .uninitialized:
                 fatalError("\(#function) invoked while still in state \(self.state)")
-            case .initializing(let client, _, _):
+            case .initializing(let client, _):
                 return client
-            case .running(let client, _, _):
+            case .running(let client, _):
                 return client
             case .finishing(let client, _):
                 return client

--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -106,7 +106,7 @@ public struct KafkaConsumerMessages: Sendable, AsyncSequence {
             while !Task.isCancelled {
                 if let client = self.cachedClient, // fast path
                    let message = try client.consumerPoll() {
-                    if message.eof && self.enablePartitionEof {
+                    if !message.eof || self.enablePartitionEof {
                         return message
                     } else {
                         continue

--- a/Sources/Kafka/KafkaError.swift
+++ b/Sources/Kafka/KafkaError.swift
@@ -44,6 +44,10 @@ public struct KafkaError: Error, CustomStringConvertible, @unchecked Sendable {
     private var line: UInt {
         self.backing.line
     }
+    
+    public var isFatal: Bool {
+        self.backing.isFatal
+    }
 
     public var description: String {
         "KafkaError.\(self.code): \(self.reason) \(self.file):\(self.line)"


### PR DESCRIPTION
## Description

These are the same changes as proposed to swift-kafka-client in [PR #158](https://github.com/swift-server/swift-kafka-client/pull/158/files#diff-8ba8c17c39d40fc29ec22c104d01bacc928df36e717000547f2a97d4203ef6a1)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [ ] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
