### PR TITLE
fix(patch): [sc-13174] use eof offset without increment

### DIFF
--- a/Sources/Kafka/RDKafka/RDKafkaClient.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaClient.swift
@@ -675,7 +675,7 @@ public final class RDKafkaClient: Sendable {
         changesList.setOffset(
             topic: message.topic,
             partition: message.partition,
-            offset: .init(rawValue: message.offset.rawValue + 1)
+            offset: message.eof ? message.offset : .init(rawValue: message.offset.rawValue + 1)
         )
 
         let error = changesList.withListPointer { listPointer in
@@ -714,7 +714,7 @@ public final class RDKafkaClient: Sendable {
             changesList.setOffset(
                 topic: message.topic,
                 partition: message.partition,
-                offset: .init(rawValue: message.offset.rawValue + 1)
+                offset: message.eof ? message.offset : .init(rawValue: message.offset.rawValue + 1)
             )
 
             // Unretained pass because the reference that librdkafka holds to capturedClosure


### PR DESCRIPTION
## Description

Not very problematic but cache groups show large lag in this case.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [ ] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
