### PR TITLE
chore(patch): avoid duplicate lz4 symbols

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,8 @@ let rdkafkaExclude = [
     "./librdkafka/src/rdkafka_sasl_win32.c",
     "./librdkafka/src/rdwin32.h",
     "./librdkafka/src/win32_config.h",
+    "./librdkafka/src/lz4.c",
+    "./librdkafka/src/lz4.h",
 ]
 
 let package = Package(
@@ -45,6 +47,7 @@ let package = Package(
         ),
     ],
     dependencies: [
+        .package(url: "https://github.com/ordo-one/package-lz4", from: "1.10.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.62.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl", from: "2.25.0"),
         .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.1.0"),
@@ -60,6 +63,7 @@ let package = Package(
             dependencies: [
                 .product(name: "NIOSSL", package: "swift-nio-ssl"),
                 .product(name: "libzstd", package: "zstd"),
+                .product(name: "lz4", package: "package-lz4"),
             ],
             exclude: rdkafkaExclude,
             sources: ["./librdkafka/src/"],


### PR DESCRIPTION
## Description

Distributed System includes package-lz4 which embeds lz4 locally instead of using system library.

This causes linker error upstream as 2 lz4 definitions are available, once from locally built lz4 in kafka and once coming in via  distrubited system:

```
/usr/bin/ld.gold: error: /home/actions/_work/ordo/ordo/.build/x86_64-unknown-linux-gnu/debug/lz4.build/lz4.c.o: multiple definition of 'LZ4_versionNumber'
/usr/bin/ld.gold: /home/actions/_work/ordo/ordo/.build/x86_64-unknown-linux-gnu/debug/Crdkafka.build/librdkafka/src/lz4.c.o: previous definition here
```

Remove locally built lz4 with kafka.