### PR TITLE
fix(major): Enable enable.auto.offset.store by default.

### DIFF
--- a/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
@@ -162,6 +162,10 @@ public struct KafkaConsumerConfiguration {
     /// Default: `.largest`
     public var autoOffsetReset: AutoOffsetReset = .largest
 
+    /// Automatically store offset of last message provided to application. The offset store is an in-memory store of the next offset to (auto-)commit for each partition.
+    /// Use rdkafka default value (true) if not set
+    public var enableAutoOffsetStore: Bool? = nil
+
     /// Allow automatic topic creation on the broker when subscribing to or assigning non-existent topics.
     /// The broker must also be configured with ``KafkaConsumerConfiguration/isAutoCreateTopicsEnabled`` = `true` for this configuration to take effect.
     /// Default: `false`
@@ -272,6 +276,9 @@ extension KafkaConsumerConfiguration {
         resultDict["max.poll.interval.ms"] = String(maximumPollInterval.inMilliseconds)
         resultDict["enable.auto.commit"] = String(isAutoCommitEnabled)
         resultDict["auto.offset.reset"] = autoOffsetReset.description
+        if let enableAutoOffsetStore {
+            resultDict["enable.auto.offset.store"] = enableAutoOffsetStore.description
+        }
         resultDict["allow.auto.create.topics"] = String(isAutoCreateTopicsEnabled)
 
         resultDict["client.id"] = identifier

--- a/Sources/Kafka/RDKafka/RDKafkaClient.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaClient.swift
@@ -90,7 +90,7 @@ public final class RDKafkaClient: Sendable {
         try RDKafkaConfig.set(configPointer: rdConfig, key: "log.queue", value: "true")
         // KafkaConsumer is manually storing read offsets
         if type == .consumer {
-            try RDKafkaConfig.set(configPointer: rdConfig, key: "enable.auto.offset.store", value: "false")
+            //try RDKafkaConfig.set(configPointer: rdConfig, key: "enable.auto.offset.store", value: "false")
             try RDKafkaConfig.set(configPointer: rdConfig, key: "enable.partition.eof", value: "true")
             if let rebalanceCallBackStorage {
                 let rebalanceCb = Unmanaged.passUnretained(rebalanceCallBackStorage)

--- a/Sources/Kafka/RDKafka/RDKafkaClient.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaClient.swift
@@ -90,7 +90,6 @@ public final class RDKafkaClient: Sendable {
         try RDKafkaConfig.set(configPointer: rdConfig, key: "log.queue", value: "true")
         // KafkaConsumer is manually storing read offsets
         if type == .consumer {
-            //try RDKafkaConfig.set(configPointer: rdConfig, key: "enable.auto.offset.store", value: "false")
             try RDKafkaConfig.set(configPointer: rdConfig, key: "enable.partition.eof", value: "true")
             if let rebalanceCallBackStorage {
                 let rebalanceCb = Unmanaged.passUnretained(rebalanceCallBackStorage)


### PR DESCRIPTION
## Description

At least `testCommittedOffsetsAreCorrect` test fails if the option is disabled.
We should override the value in own configuration if it is really required.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
