### PR TITLE
chore: zero-copy access to consumer message [sc-27729]

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -89,6 +89,9 @@ let package = Package(
                 .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Metrics", package: "swift-metrics"),
+            ],
+            swiftSettings: [
+                .enableExperimentalFeature("Lifetimes"),
             ]
         ),
         .target(

--- a/Sources/Kafka/KafkaConsumerMessage.swift
+++ b/Sources/Kafka/KafkaConsumerMessage.swift
@@ -25,41 +25,111 @@ extension FixedWidthInteger {
 
 /// A message received from the Kafka cluster.
 public struct KafkaConsumerMessage {
-    /// Internal enum for EOF, required to allow empty message
-    internal enum MessageContent: Hashable, Sendable {
-        case buffer(ByteBuffer)
-        case eof
-    }
+    @usableFromInline
+    final class Storage: @unchecked Sendable {
+        @usableFromInline
+        let messagePointer: UnsafeMutablePointer<rd_kafka_message_t>
 
-    internal var _value: MessageContent
+        init(messagePointer: UnsafeMutablePointer<rd_kafka_message_t>) {
+            self.messagePointer = messagePointer
+        }
 
-    /// The topic that the message was received from.
-    public var topic: String
-    /// The partition that the message was received from.
-    public var partition: KafkaPartition
-    /// The headers of the message.
-    public var headers: [KafkaHeader]
-    /// The key of the message.
-    public var key: ByteBuffer?
-    /// The body of the message.
-    public var value: ByteBuffer {
-        switch _value {
-        case .buffer(let byteBuffer):
-            return byteBuffer
-        case .eof:
-            return ByteBuffer()
+        deinit {
+            rd_kafka_message_destroy(messagePointer)
         }
     }
-    /// The offset of the message in its partition.
-    public var offset: KafkaOffset
 
-    /// If ``true``, means it is not a message but partition EOF event
-    public var eof: Bool {
-        switch _value {
-        case .buffer:
-            return false
-        case .eof:
-            return true
+    @usableFromInline
+    let storage: Storage
+
+    // MARK: - Nested types
+
+    /// A non-escapable, zero-copy view over the headers of a ``KafkaConsumerMessage``.
+    ///
+    /// Valid only for the duration of the enclosing ``withHeaders(_:)`` call.
+    /// Provides `count`, `isEmpty`, and subscript access without allocating a `[KafkaHeader]` array.
+    public struct Headers: ~Escapable {
+        @usableFromInline
+        let pointer: OpaquePointer?  // rd_kafka_headers_t*, nil when there are no headers
+
+        @_lifetime(immortal)
+        @usableFromInline
+        init(_ pointer: OpaquePointer?) {
+            self.pointer = pointer
+        }
+
+        /// The number of headers in the message.
+        @inlinable
+        public var count: Int {
+            guard let pointer else { return 0 }
+            return rd_kafka_header_cnt(pointer)
+        }
+
+        /// `true` if the message has no headers.
+        @inlinable
+        public var isEmpty: Bool { count == 0 }
+
+        /// Returns a ``Header`` view for the header at `index`.
+        ///
+        /// - Precondition: `index >= 0 && index < count`
+        @inlinable
+        public subscript(index: Int) -> Header {
+            @_lifetime(borrow self)
+            get {
+                guard let pointer else {
+                    preconditionFailure("index \(index) out of range: Headers is empty")
+                }
+                var keyPointer: UnsafePointer<CChar>?
+                var valuePointer: UnsafeRawPointer?
+                var valueSize = 0
+                let err = rd_kafka_header_get_all(pointer, index, &keyPointer, &valuePointer, &valueSize)
+                guard err == RD_KAFKA_RESP_ERR_NO_ERROR, let keyPointer else {
+                    preconditionFailure("Failed to read Kafka header at index \(index): \(err)")
+                }
+                let header = Header(key: keyPointer, value: valuePointer, valueSize: valueSize)
+                return _overrideLifetime(header, borrowing: self)
+            }
+        }
+    }
+
+    /// A non-escapable, zero-copy view over a single Kafka header's key and value bytes.
+    ///
+    /// Obtained via ``Headers/subscript(_:)``; valid only within the enclosing ``withHeaders(_:)`` call.
+    public struct Header: ~Escapable {
+        @usableFromInline
+        let key: UnsafePointer<CChar>
+        @usableFromInline
+        let value: UnsafeRawPointer?
+        @usableFromInline
+        let valueSize: Int
+
+        @_lifetime(immortal)
+        @usableFromInline
+        init(key: UnsafePointer<CChar>, value: UnsafeRawPointer?, valueSize: Int) {
+            self.key = key
+            self.value = value
+            self.valueSize = valueSize
+        }
+
+        /// The header name as raw UTF-8 bytes, zero-copy.
+        @inlinable
+        public var keyBytes: RawSpan {
+            @_lifetime(borrow self)
+            get {
+                let buf = UnsafeRawBufferPointer(start: UnsafeRawPointer(key), count: strlen(key))
+                return _overrideLifetime(RawSpan(_unsafeBytes: buf), borrowing: self)
+            }
+        }
+
+        /// The header value as raw bytes, or `nil` if the header has no value.
+        @inlinable
+        public var valueBytes: RawSpan? {
+            @_lifetime(borrow self)
+            get {
+                guard let value, valueSize > 0 else { return nil }
+                let buf = UnsafeRawBufferPointer(start: value, count: valueSize)
+                return _overrideLifetime(RawSpan(_unsafeBytes: buf), borrowing: self)
+            }
         }
     }
 
@@ -68,83 +138,156 @@ public struct KafkaConsumerMessage {
         case logAppendTime(Date)
     }
 
-    /// The timestamp of the Kafka message (see `rd_kafka_message_timestamp()`), if available.
-    public let timestamp: Timestamp?
-
-    /// Initialize ``KafkaConsumerMessage`` as EOF from `rd_kafka_topic_partition_t` pointer.
-    /// - Throws: A ``KafkaError`` if the received message is an error message or malformed.
-//    internal init(topicPartitionPointer: UnsafePointer<rd_kafka_topic_partition_t>) {
-//        let topicPartition = topicPartitionPointer.pointee
-//        guard let topic = String(validatingUTF8: topicPartition.topic) else {
-//            fatalError("Received topic name that is non-valid UTF-8")
-//        }
-//        self.topic = topic
-//        self.partition = KafkaPartition(rawValue: Int(topicPartition.partition))
-//        self.offset = KafkaOffset(rawValue: Int(topicPartition.offset))
-//        self.value = ByteBuffer()
-//        self.headers = [KafkaHeader]()
-//    }
-
     /// Initialize ``KafkaConsumerMessage`` from `rd_kafka_message_t` pointer.
     /// - Throws: A ``KafkaError`` if the received message is an error message or malformed.
-    internal init(messagePointer: UnsafePointer<rd_kafka_message_t>) throws {
+    internal init(messagePointer: UnsafeMutablePointer<rd_kafka_message_t>) throws {
         let rdKafkaMessage = messagePointer.pointee
 
-        guard let valuePointer = rdKafkaMessage.payload else {
-            fatalError("Could not resolve payload of consumer message")
-        }
-
-        let valueBufferPointer = UnsafeRawBufferPointer(start: valuePointer, count: rdKafkaMessage.len)
-
         guard rdKafkaMessage.err == RD_KAFKA_RESP_ERR_NO_ERROR || rdKafkaMessage.err == RD_KAFKA_RESP_ERR__PARTITION_EOF else {
-            var errorStringBuffer = ByteBuffer(bytes: valueBufferPointer)
-            let errorString = errorStringBuffer.readString(length: errorStringBuffer.readableBytes)
-
-            if let errorString {
-                throw KafkaError.messageConsumption(reason: errorString)
-            } else {
-                throw KafkaError.rdKafkaError(wrapping: rdKafkaMessage.err)
-            }
-        }
-
-        guard let topic = String(validatingCString: rd_kafka_topic_name(rdKafkaMessage.rkt)) else {
-            fatalError("Received topic name that is non-valid UTF-8")
-        }
-
-        self.topic = topic
-
-        self.partition = KafkaPartition(rawValue: Int(rdKafkaMessage.partition))
-
-        var timestamp: Timestamp? = nil
-
-        if rdKafkaMessage.err != RD_KAFKA_RESP_ERR__PARTITION_EOF {
-            var valueBuffer: ByteBuffer
-            (self.key, valueBuffer, self.headers) = try Self.extractContent(fromMessage: messagePointer)
-            self._value = .buffer(valueBuffer)
-
-            var timestampType = RD_KAFKA_TIMESTAMP_NOT_AVAILABLE
-            let kafkaTimestamp = rd_kafka_message_timestamp(messagePointer, &timestampType)
-            if kafkaTimestamp != -1 {
-                if timestampType == RD_KAFKA_TIMESTAMP_CREATE_TIME {
-                    timestamp = .createTime(.init(timeIntervalSince1970: TimeInterval(kafkaTimestamp)/1000.0))
-                } else if timestampType == RD_KAFKA_TIMESTAMP_LOG_APPEND_TIME {
-                    timestamp = .logAppendTime(.init(timeIntervalSince1970: TimeInterval(kafkaTimestamp)/1000.0))
+            defer { rd_kafka_message_destroy(messagePointer) }
+            if let valuePointer = rdKafkaMessage.payload {
+                let valueBufferPointer = UnsafeRawBufferPointer(start: valuePointer, count: rdKafkaMessage.len)
+                var errorStringBuffer = ByteBuffer(bytes: valueBufferPointer)
+                if let errorString = errorStringBuffer.readString(length: errorStringBuffer.readableBytes) {
+                    throw KafkaError.messageConsumption(reason: errorString)
                 }
             }
-        } else {
-            self._value = .eof
-            self.key = .init()
-            self.headers = .init()
+            throw KafkaError.rdKafkaError(wrapping: rdKafkaMessage.err)
         }
 
-        self.offset = KafkaOffset(rawValue: Int(rdKafkaMessage.offset))
-        self.timestamp = timestamp
+        self.storage = Storage(messagePointer: messagePointer)
+    }
+
+    /// If ``true``, means it is not a message but partition EOF event.
+    @inlinable
+    public var eof: Bool {
+        storage.messagePointer.pointee.err == RD_KAFKA_RESP_ERR__PARTITION_EOF
+    }
+
+    /// The topic that the message was received from.
+    @inlinable
+    public var topic: String {
+        guard let topic = String(validatingCString: rd_kafka_topic_name(storage.messagePointer.pointee.rkt)) else {
+            fatalError("Received topic name that is non-valid UTF-8")
+        }
+        return topic
+    }
+
+    /// The partition that the message was received from.
+    @inlinable
+    public var partition: KafkaPartition {
+        KafkaPartition(rawValue: Int(storage.messagePointer.pointee.partition))
+    }
+
+    /// The offset of the message in its partition.
+    @inlinable
+    public var offset: KafkaOffset {
+        KafkaOffset(rawValue: Int(storage.messagePointer.pointee.offset))
+    }
+
+    /// The key of the message.
+    @inlinable
+    public var key: ByteBuffer? {
+        guard !eof else { return nil }
+        let msg = storage.messagePointer.pointee
+        guard msg.key_len > 0 else { return nil }
+        return ByteBuffer(bytes: UnsafeRawBufferPointer(start: msg.key, count: msg.key_len))
+    }
+
+    /// The body of the message.
+    @inlinable
+    public var value: ByteBuffer {
+        guard !eof else { return ByteBuffer() }
+        let msg = storage.messagePointer.pointee
+        guard let payload = msg.payload else { return ByteBuffer() }
+        return ByteBuffer(bytes: UnsafeRawBufferPointer(start: payload, count: msg.len))
+    }
+
+    /// Calls `body` with a ``RawSpan`` over the raw payload bytes of the message,
+    /// avoiding a copy. The span is only valid for the duration of the call.
+    ///
+    /// Returns an empty span for EOF messages or messages with no payload.
+    @inlinable
+    @discardableResult
+    public func withValueBytes<Result>(_ body: (RawSpan) throws -> Result) rethrows -> Result {
+        guard !eof else {
+            return try body(RawSpan(_unsafeBytes: UnsafeRawBufferPointer(start: nil, count: 0)))
+        }
+        let msg = storage.messagePointer.pointee
+        guard let payload = msg.payload else {
+            return try body(RawSpan(_unsafeBytes: UnsafeRawBufferPointer(start: nil, count: 0)))
+        }
+        return try body(RawSpan(_unsafeBytes: UnsafeRawBufferPointer(start: payload, count: msg.len)))
+    }
+
+    /// Calls `body` with an optional ``RawSpan`` over the raw key bytes of the message,
+    /// avoiding a copy. The span is only valid for the duration of the call.
+    ///
+    /// Passes `nil` if the message has no key or is an EOF message.
+    @inlinable
+    @discardableResult
+    public func withKeyBytes<Result>(_ body: (RawSpan?) throws -> Result) rethrows -> Result {
+        guard !eof else { return try body(nil) }
+        let msg = storage.messagePointer.pointee
+        guard msg.key_len > 0 else { return try body(nil) }
+        return try body(RawSpan(_unsafeBytes: UnsafeRawBufferPointer(start: msg.key, count: msg.key_len)))
+    }
+
+    /// The headers of the message, copied into an array.
+    public var headers: [KafkaHeader] {
+        guard !eof else { return [] }
+        return (try? Self.extractHeaders(fromMessage: storage.messagePointer)) ?? []
+    }
+
+    /// Calls `body` with a zero-copy ``Headers`` view over the message's headers.
+    ///
+    /// The ``Headers`` value — and any ``Header`` or ``RawSpan`` derived from it —
+    /// must not escape the closure.
+    @inlinable
+    @discardableResult
+    public func withHeaders<R>(_ body: (borrowing Headers) throws -> R) rethrows -> R {
+        guard !eof else {
+            return try body(_overrideLifetime(Headers(nil), borrowing: self))
+        }
+        var headersPtr: OpaquePointer?
+        let status = rd_kafka_message_headers(storage.messagePointer, &headersPtr)
+        guard status == RD_KAFKA_RESP_ERR_NO_ERROR || status == RD_KAFKA_RESP_ERR__NOENT else {
+            return try body(_overrideLifetime(Headers(nil), borrowing: self))
+        }
+        return try body(_overrideLifetime(Headers(headersPtr), borrowing: self))
+    }
+
+    /// The timestamp of the Kafka message (see `rd_kafka_message_timestamp()`), if available.
+    @inlinable
+    public var timestamp: Timestamp? {
+        guard !eof else { return nil }
+        var timestampType = RD_KAFKA_TIMESTAMP_NOT_AVAILABLE
+        let kafkaTimestamp = rd_kafka_message_timestamp(storage.messagePointer, &timestampType)
+        guard kafkaTimestamp != -1 else { return nil }
+        if timestampType == RD_KAFKA_TIMESTAMP_CREATE_TIME {
+            return .createTime(.init(timeIntervalSince1970: TimeInterval(kafkaTimestamp) / 1000.0))
+        } else if timestampType == RD_KAFKA_TIMESTAMP_LOG_APPEND_TIME {
+            return .logAppendTime(.init(timeIntervalSince1970: TimeInterval(kafkaTimestamp) / 1000.0))
+        }
+        return nil
     }
 }
 
 // MARK: - KafkaConsumerMessage + Hashable
 
-extension KafkaConsumerMessage: Hashable {}
+extension KafkaConsumerMessage: Hashable {
+    @inlinable
+    public static func == (lhs: KafkaConsumerMessage, rhs: KafkaConsumerMessage) -> Bool {
+        lhs.topic == rhs.topic && lhs.partition == rhs.partition && lhs.offset == rhs.offset
+    }
+
+    @inlinable
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(topic)
+        hasher.combine(partition)
+        hasher.combine(offset)
+    }
+}
 
 // MARK: - KafkaConsumerMessage + Sendable
 
@@ -154,6 +297,18 @@ extension KafkaConsumerMessage: Sendable {}
 
 extension KafkaConsumerMessage {
     static let bufferAlignment: Int = MemoryLayout<UInt64>.size
+
+    /// Extracts headers from a `rd_kafka_message_t` pointer.
+    static func extractHeaders(
+        fromMessage messagePointer: UnsafePointer<rd_kafka_message_t>
+    ) throws -> [KafkaHeader] {
+        var headers = [KafkaHeader]()
+        try Self.forEachHeader(inMessage: messagePointer) { key, value in
+            let valueBuffer: ByteBuffer? = value.count > 0 ? ByteBuffer(bytes: value) : nil
+            headers.append(KafkaHeader(key: String(cString: key), value: valueBuffer))
+        }
+        return headers
+    }
 
     static func extractContent(
         fromMessage messagePointer: UnsafePointer<rd_kafka_message_t>

--- a/Sources/Kafka/KafkaConsumerMessage.swift
+++ b/Sources/Kafka/KafkaConsumerMessage.swift
@@ -79,25 +79,25 @@ public struct KafkaConsumerMessage {
                 guard let pointer else {
                     preconditionFailure("index \(index) out of range: Headers is empty")
                 }
-                var keyPointer: UnsafePointer<CChar>?
+                var namePointer: UnsafePointer<CChar>?
                 var valuePointer: UnsafeRawPointer?
                 var valueSize = 0
-                let err = rd_kafka_header_get_all(pointer, index, &keyPointer, &valuePointer, &valueSize)
-                guard err == RD_KAFKA_RESP_ERR_NO_ERROR, let keyPointer else {
+                let err = rd_kafka_header_get_all(pointer, index, &namePointer, &valuePointer, &valueSize)
+                guard err == RD_KAFKA_RESP_ERR_NO_ERROR, let namePointer else {
                     preconditionFailure("Failed to read Kafka header at index \(index): \(err)")
                 }
-                let header = Header(key: keyPointer, value: valuePointer, valueSize: valueSize)
+                let header = Header(name: namePointer, value: valuePointer, valueSize: valueSize)
                 return _overrideLifetime(header, borrowing: self)
             }
         }
     }
 
-    /// A non-escapable, zero-copy view over a single Kafka header's key and value bytes.
+    /// A non-escapable, zero-copy view over a single Kafka header's name and value bytes.
     ///
     /// Obtained via ``Headers/subscript(_:)``; valid only within the enclosing ``withHeaders(_:)`` call.
     public struct Header: ~Escapable {
         @usableFromInline
-        let key: UnsafePointer<CChar>
+        let _name: UnsafePointer<CChar>
         @usableFromInline
         let value: UnsafeRawPointer?
         @usableFromInline
@@ -105,19 +105,31 @@ public struct KafkaConsumerMessage {
 
         @_lifetime(immortal)
         @usableFromInline
-        init(key: UnsafePointer<CChar>, value: UnsafeRawPointer?, valueSize: Int) {
-            self.key = key
+        init(name: UnsafePointer<CChar>, value: UnsafeRawPointer?, valueSize: Int) {
+            self._name = name
             self.value = value
             self.valueSize = valueSize
         }
 
-        /// The header name as raw UTF-8 bytes, zero-copy.
+        /// The header name, copied into a `String`.
         @inlinable
-        public var keyBytes: RawSpan {
+        public var name: String {
+            String(cString: _name)
+        }
+
+        /// The header name as a zero-copy UTF-8 span.
+        ///
+        /// librdkafka header names are always null-terminated and valid UTF-8.
+        @available(macOS 26.0, *)
+        @inlinable
+        public var nameBytes: UTF8Span {
             @_lifetime(borrow self)
             get {
-                let buf = UnsafeRawBufferPointer(start: UnsafeRawPointer(key), count: strlen(key))
-                return _overrideLifetime(RawSpan(_unsafeBytes: buf), borrowing: self)
+                let nameUInt8 = UnsafeRawPointer(_name).assumingMemoryBound(to: UInt8.self)
+                let buf = UnsafeBufferPointer<UInt8>(start: nameUInt8, count: strlen(_name))
+                let span = Span<UInt8>(_unsafeElements: buf)
+                let utf8 = try! UTF8Span(validating: span)
+                return _overrideLifetime(utf8, borrowing: self)
             }
         }
 

--- a/Sources/Kafka/RDKafka/RDKafkaClient.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaClient.swift
@@ -568,18 +568,9 @@ public final class RDKafkaClient: Sendable {
             return nil
         }
 
-        defer {
-            // Destroy message otherwise poll() will block forever
-            rd_kafka_message_destroy(messagePointer)
-        }
-
-        // Reached the end of the topic+partition queue on the broker
-        if messagePointer.pointee.err == RD_KAFKA_RESP_ERR__PARTITION_EOF {
-            return try KafkaConsumerMessage(messagePointer: messagePointer)
-        }
-
-        let message = try KafkaConsumerMessage(messagePointer: messagePointer)
-        return message
+        // Ownership of messagePointer is transferred to KafkaConsumerMessage.Storage,
+        // which calls rd_kafka_message_destroy in its deinit.
+        return try KafkaConsumerMessage(messagePointer: messagePointer)
     }
     /// Atomic  incremental assignment of partitions to consume.
     /// - Parameter topicPartitionList: Pointer to a list of topics + partition pairs.


### PR DESCRIPTION
## Description

Replace eager field extraction with ARC-managed Storage class that holds the raw rd_kafka_message_t pointer for its lifetime. All properties (topic, partition, offset, key, value, eof, timestamp, headers) are now lazy computed accessors that read directly from the pointer, eliminating upfront allocations on every poll.

Zero-copy byte access:
- withValueBytes(_:) and withKeyBytes(_:) expose payload/key as RawSpan valid only within the closure, avoiding ByteBuffer allocation entirely.
- withHeaders(_:) provides a non-escapable Headers view backed directly by librdkafka memory; subscript returns a non-escapable Header whose keyBytes and valueBytes are RawSpan, with no [KafkaHeader] array allocated.
- ~Escapable lifetime safety is enforced via _overrideLifetime, tying spans to the enclosing message storage.

Copying accessors (key, value, headers) are preserved for callers that need owned values, but are no longer called on the hot poll path.

Ownership transfer: rd_kafka_message_destroy is removed from the poll site in RDKafkaClient and moved into Storage.deinit, so the pointer is freed exactly once when the last reference to the message is released.

Enables the Lifetimes experimental Swift feature in Package.swift. Adds explicit Hashable conformance keyed on (topic, partition, offset).

Include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [ ] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
