### PR TITLE
fix: don't return EOF message when not requested [sc-30533]

### DIFF
--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -117,7 +117,9 @@ public struct KafkaConsumerMessages: Sendable, AsyncSequence {
                             queue,
                             operation: { try client.consumerPoll(for: Int32(self.pollInterval.inMilliseconds)) }
                         ) {
-                            return message
+                            if !message.eof || self.enablePartitionEof {
+                                return message
+                            }
                         }
                     } else {
                         // No messages. Sleep a little.


### PR DESCRIPTION
## Description

Message iterator in KafkaConsumer shouldn't return EOF message when not requested in configuration.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
