### PR TITLE
fix(patch): eagerly parse Kafka message headers to ensure true Sendable safety [sc-27729]

### DIFF
--- a/Sources/Kafka/KafkaConsumerMessage.swift
+++ b/Sources/Kafka/KafkaConsumerMessage.swift
@@ -37,6 +37,10 @@ public struct KafkaConsumerMessage {
 
         init(messagePointer: UnsafeMutablePointer<rd_kafka_message_t>) {
             self.messagePointer = messagePointer
+
+            // Force lazy init now, single-threaded, before this becomes Sendable
+            var headersPtr: OpaquePointer?
+            _ = rd_kafka_message_headers(messagePointer, &headersPtr)
         }
 
         deinit {


### PR DESCRIPTION
## Description

`rd_kafka_message_headers()` does lazy, non-thread-safe header parsing by writing `rkm_headers` without synchronization. `KafkaConsumerMessage.Storage` was marked `@unchecked Sendable`, but sharing a message across concurrent tasks triggered a data race in `rd_kafka_msg_headers_parse()`, corrupting the internal header list and causing a crash.

Force header parsing in `Storage.init()` while still single-threaded, so all concurrent callers hit only the lock-free fast path.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
